### PR TITLE
Specify "embulkHome" instead of "into" in InstallEmbulkRunSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories {
 }
 
 installEmbulkRunSet {
-    into "path/to/embulk-home"  // Set your Embulk home directory to install the Embulk plugins.
+    embulkHome file("path/to/embulk-home")  // Set your Embulk home directory (absolute path) to install the Embulk plugins.
 
     artifact "org.embulk:embulk-input-postgresql:0.13.2"
     artifact group: "org.embulk", name: "embulk-input-s3", version: "0.6.0"

--- a/src/test/resources/simple/build.gradle
+++ b/src/test/resources/simple/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 installEmbulkRunSet {
-    into "${project.buildDir}/simple"
+    embulkHome file("${project.buildDir}/simple")
     artifact "org.embulk:embulk-input-postgresql:0.13.2"
     artifact group: "org.embulk", name: "embulk-input-s3", version: "0.6.0"
 }


### PR DESCRIPTION
This Gradle plugin intends to "set up" all files under the Embulk Home, not only Maven artifacts, but also `embulk.properties` and else.

Just reusing the existing `into` (in `Copy`) is not good. We'll want it to be explicit `embulkHome`.