### PR TITLE
Enable dependency locks with cleaning up build.gradle and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note that everything (including syntax, behavior, and else) can change drastical
 Usage
 ------
 
-Set up Gradle 8.4 or later (often with [the Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html)), and prepare `build.gradle` like below.
+Set up Gradle 8.7 or later, and make `build.gradle` like below.
 
 ```
 plugins {
@@ -27,4 +27,4 @@ installEmbulkRunSet {
 }
 ```
 
-Then run `./gradlew installEmbulkRunSet`.
+Run `./gradlew installEmbulkRunSet`, then.

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,16 @@ repositories {
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
 version = "0.1.1-SNAPSHOT"
-description = "A Gradle plugin to prepare an environment for running Embulk"
+description = "A Gradle plugin to set up an environment for running Embulk"
+
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
 
 tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked"
     options.encoding = "UTF-8"
-    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }
 
 java {
@@ -41,6 +46,19 @@ jar {
     from rootProject.file("LICENSE")
 }
 
+// A safer and strict alternative to: "dependencies" (and "dependencies --write-locks")
+//
+// This task fails explicitly when the specified dependency is not available.
+// In contrast, "dependencies (--write-locks)" does not fail even when a part the dependencies are unavailable.
+//
+// https://docs.gradle.org/8.7/userguide/dependency_locking.html#generating_and_updating_dependency_locks
+task checkDependencies {
+    notCompatibleWithConfigurationCache("The task \"checkDependencies\" filters configurations at execution time.")
+    doLast {
+        configurations.findAll { it.canBeResolved }.each { it.resolve() }
+    }
+}
+
 gradlePlugin {
     website = "https://www.embulk.org/"
     vcsUrl = "https://github.com/embulk/gradle-embulk-runset"
@@ -48,7 +66,7 @@ gradlePlugin {
     plugins {
         embulkPluginsPlugin {
             id = "org.embulk.runset"
-            displayName = "A Gradle plugin to prepare an environment for running Embulk"
+            displayName = "A Gradle plugin to set up an environment for running Embulk"
             description = "${project.description}"
             implementationClass = "org.embulk.gradle.runset.EmbulkRunSetPlugin"
             tags = ["embulk"]
@@ -66,6 +84,13 @@ test {
         showStackTraces = true
         showStandardStreams = true
         events "passed", "skipped", "failed", "standardOut", "standardError"
+    }
+}
+
+tasks.withType(Checkstyle) {
+    reports {
+        // Not to skip up-to-date checkstyles.
+        outputs.upToDateWhen { false }
     }
 }
 

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=compileClasspath,runtimeClasspath

--- a/settings-gradle.lockfile
+++ b/settings-gradle.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=incomingCatalogForLibs0


### PR DESCRIPTION
Enable dependency locks for this project (even though it has no dependencies, we can confirm no any unexpected dependency is added in the future) + some cleanups in `build.gradle` and `README.md`.