### PR TITLE
Bump up to v0.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 // They want Gradle plugins to be published under the "gradle.plugin" prefix for some security reasons.
 // https://plugins.gradle.org/docs/publish-plugin
 group = "org.embulk"
-version = "0.1.1-SNAPSHOT"
+version = "0.2.0-SNAPSHOT"
 description = "A Gradle plugin to prepare an environment for running Embulk"
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
I have been adding changes in this Gradle plugin to be `v0.1.1`, but I had many changes, including an incompatible change from `into` to `embulkHome`. We'll want to set the next version to `v0.2.0`.