### PR TITLE
Install Maven artifacts under "m2_repo"

### DIFF
--- a/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
+++ b/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
@@ -52,7 +52,8 @@ public class TestEmbulkRunSetPlugin  {
         try (final InputStream in = Files.newInputStream(propertiesPath)) {
             properties.load(in);
         }
-        assertEquals(1, properties.size());
+        assertEquals(2, properties.size());
         assertEquals("value", properties.getProperty("key"));
+        assertEquals("lib/m2/repository", properties.getProperty("m2_repo"));
     }
 }

--- a/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
+++ b/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Properties;
@@ -54,6 +55,6 @@ public class TestEmbulkRunSetPlugin  {
         }
         assertEquals(2, properties.size());
         assertEquals("value", properties.getProperty("key"));
-        assertEquals("lib/m2/repository", properties.getProperty("m2_repo"));
+        assertEquals(Paths.get("lib").resolve("m2").resolve("repository").toString(), properties.getProperty("m2_repo"));
     }
 }

--- a/src/test/resources/simple/build.gradle
+++ b/src/test/resources/simple/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 installEmbulkRunSet {
     embulkHome file("${project.buildDir}/simple")
+    m2RepoRelative "lib/m2/repository"
     embulkSystemProperty "key", "value"
     artifact "org.embulk:embulk-input-postgresql:0.13.2"
     artifact group: "org.embulk", name: "embulk-input-s3", version: "0.6.0"


### PR DESCRIPTION
Maven artifacts (plugins) are to be installed in the "m2_repo" directory under the Embulk home directory, not directly in the Embulk home.

See EEP-4: System-wide Configuration by Embulk System Properties and Embulk Home https://github.com/embulk/embulk/blob/master/docs/eeps/eep-0004.md

This change is to follow the convention.

"m2_repo" can be configured by the "m2RepoRelative" notation in "installEmbulkRunSet". The default "m2_repo" is "lib/m2/repository".