### PR TITLE
Install jruby-complete.jar, and set "jruby"

### DIFF
--- a/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
+++ b/src/test/java/org/embulk/gradle/runset/TestEmbulkRunSetPlugin.java
@@ -19,9 +19,12 @@ package org.embulk.gradle.runset;
 import static org.embulk.gradle.runset.Util.prepareProjectDir;
 import static org.embulk.gradle.runset.Util.runGradle;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,7 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class TestEmbulkRunSetPlugin  {
     @Test
-    public void testSimple(@TempDir Path tempDir) throws IOException {
+    public void testSimple(@TempDir Path tempDir) throws IOException, URISyntaxException {
         final Path projectDir = prepareProjectDir(tempDir, "simple");
 
         runGradle(projectDir, "installEmbulkRunSet");
@@ -53,8 +56,21 @@ public class TestEmbulkRunSetPlugin  {
         try (final InputStream in = Files.newInputStream(propertiesPath)) {
             properties.load(in);
         }
-        assertEquals(2, properties.size());
+        assertEquals(3, properties.size());
         assertEquals("value", properties.getProperty("key"));
         assertEquals(Paths.get("lib").resolve("m2").resolve("repository").toString(), properties.getProperty("m2_repo"));
+        final URI jrubyUri = new URI(properties.getProperty("jruby"));
+        assertEquals("file", jrubyUri.getScheme());
+        final Path jrubyAbsolutePath = Paths.get(jrubyUri);
+        assertTrue(jrubyAbsolutePath.isAbsolute());
+        assertTrue(jrubyAbsolutePath.endsWith(
+                       Paths.get("lib")
+                       .resolve("m2")
+                       .resolve("repository")
+                       .resolve("org")
+                       .resolve("jruby")
+                       .resolve("jruby-complete")
+                       .resolve("9.1.15.0")
+                       .resolve("jruby-complete-9.1.15.0.jar")));
     }
 }

--- a/src/test/resources/simple/build.gradle
+++ b/src/test/resources/simple/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 installEmbulkRunSet {
     embulkHome file("${project.buildDir}/simple")
+    jruby "org.jruby:jruby-complete:9.1.15.0"
     m2RepoRelative "lib/m2/repository"
     embulkSystemProperty "key", "value"
     artifact "org.embulk:embulk-input-postgresql:0.13.2"


### PR DESCRIPTION
When using JRuby, Embulk expects to have an Embulk System Property `jruby` with a `file:` URI, such as `jruby=file:///path/to/jruby-complete.9.x.y.z.jar`

See EEP-6: JRuby as Optional
https://github.com/embulk/embulk/blob/master/docs/eeps/eep-0006.md

This change is to add a new `jruby` notation in `installEmbulkRunSet` to download jruby-complete.jar, and set the `jruby` property.